### PR TITLE
Fix ed2ksum test application

### DIFF
--- a/ed2ksum/ed2ksum.go
+++ b/ed2ksum/ed2ksum.go
@@ -3,7 +3,6 @@ package main
 import (
 	"flag"
 	"fmt"
-	"github.com/Kovensky/go-ed2k"
 	"io"
 	"io/ioutil"
 	"os"
@@ -11,6 +10,8 @@ import (
 	"runtime"
 	"strconv"
 	"strings"
+
+	ed2k "github.com/kristinnardal2/go-ed2k"
 )
 
 var useNullChunk = flag.Bool("null-chunk", false,
@@ -21,20 +22,24 @@ var checkMode = flag.Bool("c", false,
 var uriMode = flag.Bool("uri", false,
 	`If true, outputs ed2k URIs instead of a verifiable digest.`)
 
-func hashFile(chunkMode bool, path string) (hash string, err error) {
+func hashFile(chunkMode bool, path string) (string, error) {
 	var fh *os.File
+	var err error
 	if path == "-" {
 		fh = os.Stdin
 	} else {
 		fh, err = os.Open(path)
 		if err != nil {
-			return
+			return "", err
 		}
 		defer fh.Close()
 	}
 
 	ed2k := ed2k.New(chunkMode)
-	io.Copy(ed2k, fh)
+	_, err = io.Copy(ed2k, fh)
+	if err != nil {
+		return "", err
+	}
 	return ed2k.(fmt.Stringer).String(), err
 }
 

--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,6 @@ module github.com/kristinnardal2/go-ed2k
 
 go 1.19
 
-require golang.org/x/crypto v0.1.0 // indirect
+require golang.org/x/crypto v0.1.0
+
+replace github.com/kristinnardal2/go-ed2k => ./


### PR DESCRIPTION
We fix it by importing from the new fork, as well as replacing the mod with the local git folder.

```
go mod edit -replace github.com/kristinnardal2/go-ed2k=./
```

I've also changed the hashFile function slightly, there was no need to have named returned in the hashFile function. We also check the output of the io.Copy function.