### PR TITLE
Move golangci-lint to it's own workflow

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.go text eol=lf

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -26,8 +26,3 @@ jobs:
 
     - name: Test
       run: go test -v ./...
-      
-    - name: Run golangci-lint
-      uses: golangci/golangci-lint-action@v3.3.0
-      with:
-        only-new-issues: true

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -1,0 +1,20 @@
+name: golangci-lint
+on:
+  push:
+    pull_request:
+permissions:
+  contents: read
+  pull-requests: read
+jobs:
+  golangci:
+    name: lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/setup-go@v3
+        with:
+          go-version: 1.19
+      - uses: actions/checkout@v3
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v3.3.0
+        with:
+          only-new-issues: true


### PR DESCRIPTION
This is the recommended way of using the golangci-lint action. I've also changed it so that this only runs on pull requests and not pushes to the master branch.