### PR TITLE
Fix golangci-lint workflow running on master branch

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -1,7 +1,6 @@
 name: golangci-lint
 on:
-  push:
-    pull_request:
+  pull_request:
 permissions:
   contents: read
   pull-requests: read


### PR DESCRIPTION
This should only run on pull requests, this fixes that issue