### PR TITLE
Fix all lint errors returned by golangci-lint

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,3 @@
+issues:
+  exclude:
+    - "golang.org/x/crypto/md4"

--- a/ed2ksum/ed2ksum.go
+++ b/ed2ksum/ed2ksum.go
@@ -4,7 +4,6 @@ import (
 	"flag"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"regexp"
 	"runtime"
@@ -133,7 +132,7 @@ func main() {
 				}
 				defer fh.Close()
 			}
-			digest, err := ioutil.ReadAll(fh)
+			digest, err := io.ReadAll(fh)
 			if err != nil {
 				fmt.Fprintln(os.Stderr, err)
 			} else {


### PR DESCRIPTION
We don't care that the md4 algorithm isn't cryptographically secure, we are not using it for anything like that.

I've handled all appropriate errors from io.Copy and io.CopyN and explicitly ignored when not appropriate.

I've also renamed the testing.T and testing.B variables in the tests to be what they are usually named.